### PR TITLE
Add platform x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -303,6 +305,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
- Add a platform to fix errors when deploying Heroku's app
```Bundler Output: Your bundle only supports platforms ["x86_64-darwin-21"] but your local platform is x86_64-linux. Add the current platform to the lock file with `bundle lock --add-platform x86_64-linux` and try again.```