### PR TITLE
Dependent destroy

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -2,9 +2,9 @@ class Member < ApplicationRecord
   # :confirmable removed from the list on the deployed version
   devise :database_authenticatable, :registerable, :recoverable, :rememberable,
          :validatable, :omniauthable, omniauth_providers: %i[github google_oauth2]
-  has_many :comments, foreign_key: 'author_id'
-  has_many :likes, foreign_key: 'author_id'
-  has_many :posts, foreign_key: 'author_id'
+  has_many :comments, foreign_key: 'author_id', dependent: :destroy
+  has_many :likes, foreign_key: 'author_id', dependent: :destroy
+  has_many :posts, foreign_key: 'author_id', dependent: :destroy
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [110, 110]
   end


### PR DESCRIPTION
- Dependent destroy rule created to delete posts, comments, and likes when destroying a user.